### PR TITLE
Add player attack and platform enemy

### DIFF
--- a/scenes/pacing_enemy.gd
+++ b/scenes/pacing_enemy.gd
@@ -1,0 +1,19 @@
+extends CharacterBody2D
+
+@export var move_speed: float = 60.0
+@export var gravity: float = 900.0
+
+@onready var floor_check: RayCast2D = $FloorCheck
+var direction: int = -1
+
+func _physics_process(delta: float) -> void:
+    velocity.y += gravity * delta
+    velocity.x = move_speed * direction
+    move_and_slide()
+
+    floor_check.position.x = abs(floor_check.position.x) * direction
+    if is_on_wall() or not floor_check.is_colliding():
+        direction *= -1
+
+func hit() -> void:
+    queue_free()

--- a/scenes/pacing_enemy.tscn
+++ b/scenes/pacing_enemy.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scenes/pacing_enemy.gd" id="1_script"]
+[ext_resource type="Texture2D" uid="uid://cuualr3ppvl4u" path="res://sprites/Threat.png" id="2_tex"]
+
+[sub_resource type="RectangleShape2D" id="Shape"]
+extents = Vector2(16, 16)
+
+[node name="PacingEnemy" type="CharacterBody2D" groups=["enemy"]]
+motion_mode = 1
+script = ExtResource("1_script")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2_tex")
+scale = Vector2(0.05, 0.05)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("Shape")
+
+[node name="FloorCheck" type="RayCast2D" parent="."]
+position = Vector2(16, 32)
+target_position = Vector2(16, 48)
+collide_with_areas = false

--- a/scenes/player.gd
+++ b/scenes/player.gd
@@ -1,0 +1,49 @@
+extends CharacterBody2D
+
+@export var speed: float = 200.0
+@export var jump_velocity: float = -400.0
+@export var gravity: float = 900.0
+@export var attack_time: float = 0.2
+@export var attack_cooldown: float = 0.3
+
+@onready var attack_area: Area2D = $AttackArea
+
+func _ready() -> void:
+    attack_area.body_entered.connect(_on_attack_area_body_entered)
+    attack_area.monitoring = false
+
+var attacking: bool = false
+var facing: int = 1
+var velocity: Vector2 = Vector2.ZERO
+
+func _physics_process(delta: float) -> void:
+    velocity.y += gravity * delta
+
+    var direction := Input.get_action_strength("ui_right") - Input.get_action_strength("ui_left")
+    if direction != 0:
+        facing = sign(direction)
+    velocity.x = direction * speed
+
+    if is_on_floor() and Input.is_action_just_pressed("ui_accept"):
+        velocity.y = jump_velocity
+
+    move_and_slide()
+    attack_area.position.x = abs(attack_area.position.x) * facing
+
+    if Input.is_action_just_pressed("attack") and not attacking:
+        start_attack()
+
+func start_attack() -> void:
+    attacking = true
+    attack_area.monitoring = true
+    var timer = get_tree().create_timer(attack_time)
+    timer.timeout.connect(end_attack)
+
+func end_attack() -> void:
+    attack_area.monitoring = false
+    await get_tree().create_timer(attack_cooldown).timeout
+    attacking = false
+
+func _on_attack_area_body_entered(body: Node) -> void:
+    if body.has_method("hit"):
+        body.hit()

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scenes/player.gd" id="1_abc"]
+[ext_resource type="Texture2D" uid="uid://c6sbnebmlurxw" path="res://sprites/bettersprites/DefenderJelly.png" id="2_tex"]
+
+[sub_resource type="CircleShape2D" id="Shape"]
+radius = 32.0
+
+[node name="Player" type="CharacterBody2D"]
+motion_mode = 1
+script = ExtResource("1_abc")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2_tex")
+scale = Vector2(0.075, 0.075)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("Shape")
+
+[node name="AttackArea" type="Area2D" parent="."]
+monitoring = false
+collision_layer = 0
+collision_mask = 1
+
+[node name="HitBox" type="CollisionShape2D" parent="AttackArea"]
+shape = SubResource("Shape")
+position = Vector2(40, 0)


### PR DESCRIPTION
## Summary
- add a simple Player scene with an attack hitbox
- implement attack logic in `player.gd`
- create `PacingEnemy` that walks back and forth

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684913cdaacc8327859391052b24848e